### PR TITLE
Fixes bug which applied settings with wrong selector to config.

### DIFF
--- a/src/main/java/me/magnet/consultant/ServiceIdentifier.java
+++ b/src/main/java/me/magnet/consultant/ServiceIdentifier.java
@@ -47,21 +47,34 @@ public class ServiceIdentifier {
 		return instance;
 	}
 
-	public boolean appliesTo(ServiceIdentifier mask) {
-		checkNotNull(mask, "You must specify a 'mask'!");
+	public boolean appliesTo(ServiceIdentifier serviceIdentifier) {
+		checkNotNull(serviceIdentifier, "You must specify a 'serviceIdentifier'!");
 
-		if (!mask.getServiceName().equals(getServiceName())) {
+		if (!getServiceName().equals(serviceIdentifier.getServiceName())) {
 			return false;
 		}
-		else if (mask.getDatacenter().isPresent() && (getDatacenter().isPresent() && !mask.getDatacenter().equals(getDatacenter()))) {
+		else if (!matches(getDatacenter(), serviceIdentifier.getDatacenter())) {
 			return false;
 		}
-		else if (mask.getHostName().isPresent() && (getHostName().isPresent() && !mask.getHostName().equals(getHostName()))) {
+		else if (!matches(getHostName(), serviceIdentifier.getHostName())) {
 			return false;
 		}
-		else if (mask.getInstance().isPresent() && (getInstance().isPresent() && !mask.getInstance().equals(getInstance()))) {
+		else if (!matches(getInstance(), serviceIdentifier.getInstance())) {
 			return false;
 		}
+		return true;
+	}
+
+	private <T> boolean matches(Optional<T> left, Optional<T> right) {
+		if (left.isPresent() && right.isPresent()) {
+			// Both values are set, they must match.
+			return left.get().equals(right.get());
+		}
+		else if (left.isPresent()) {
+			// Only the matching value is set, accept nothing.
+			return false;
+		}
+		// Either the matching value is not set so accept everything.
 		return true;
 	}
 

--- a/src/test/java/me/magnet/consultant/ServiceIdentifierTest.java
+++ b/src/test/java/me/magnet/consultant/ServiceIdentifierTest.java
@@ -71,7 +71,7 @@ public class ServiceIdentifierTest {
 		ServiceIdentifier id1 = new ServiceIdentifier("oauth", null, null, null);
 		ServiceIdentifier id2 = new ServiceIdentifier("oauth", "eu-central", "web-1", "master");
 
-		assertTrue(id2.appliesTo(id1));
+		assertFalse(id2.appliesTo(id1));
 		assertTrue(id1.appliesTo(id2));
 	}
 
@@ -89,7 +89,7 @@ public class ServiceIdentifierTest {
 		ServiceIdentifier id1 = new ServiceIdentifier("oauth", "eu-central", null, null);
 		ServiceIdentifier id2 = new ServiceIdentifier("oauth", "eu-central", "web-1", "master");
 
-		assertTrue(id2.appliesTo(id1));
+		assertFalse(id2.appliesTo(id1));
 		assertTrue(id1.appliesTo(id2));
 	}
 
@@ -107,7 +107,7 @@ public class ServiceIdentifierTest {
 		ServiceIdentifier id1 = new ServiceIdentifier("oauth", null, "web-1", null);
 		ServiceIdentifier id2 = new ServiceIdentifier("oauth", "eu-central", "web-1", "master");
 
-		assertTrue(id2.appliesTo(id1));
+		assertFalse(id2.appliesTo(id1));
 		assertTrue(id1.appliesTo(id2));
 	}
 
@@ -125,7 +125,7 @@ public class ServiceIdentifierTest {
 		ServiceIdentifier id1 = new ServiceIdentifier("oauth", null, null, "master");
 		ServiceIdentifier id2 = new ServiceIdentifier("oauth", "eu-central", "web-1", "master");
 
-		assertTrue(id2.appliesTo(id1));
+		assertFalse(id2.appliesTo(id1));
 		assertTrue(id1.appliesTo(id2));
 	}
 


### PR DESCRIPTION
There were instances where `[dc=development].some-setting` applied to service instances not running in the `development` datacenter. This PR fixes that, and adds tests to prevent this in the future.