### PR TITLE
Skip folder keys in consul's key/value store.

### DIFF
--- a/src/main/java/me/magnet/consultant/ConfigUpdater.java
+++ b/src/main/java/me/magnet/consultant/ConfigUpdater.java
@@ -136,7 +136,7 @@ class ConfigUpdater implements Runnable {
 
 		for (KeyValueEntry entry : entries) {
 			Path path = PathParser.parse(PREFIX, entry.getKey());
-			if (path == null) {
+			if (path == null || path.getKey() == null) {
 				continue;
 			}
 


### PR DESCRIPTION
This PR ensures that consultant will ignore keys ending with `/`. These "folder" keys can be made through the web UI, but serve no purpose for consultant. This prevents a `NullPointerException` from being thrown.

Close #3 