### PR TITLE
Add support for service registration and deregistration.

### DIFF
--- a/src/main/java/me/magnet/consultant/Check.java
+++ b/src/main/java/me/magnet/consultant/Check.java
@@ -1,0 +1,20 @@
+package me.magnet.consultant;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Check {
+
+	@JsonProperty("HTTP")
+	private final String http;
+
+	@JsonProperty("Interval")
+	private final Integer interval;
+
+	Check(String http, Integer interval) {
+		this.http = http;
+		this.interval = interval;
+	}
+
+}

--- a/src/main/java/me/magnet/consultant/ConsultantException.java
+++ b/src/main/java/me/magnet/consultant/ConsultantException.java
@@ -1,0 +1,17 @@
+package me.magnet.consultant;
+
+public class ConsultantException extends RuntimeException {
+
+	public ConsultantException(String message) {
+		super(message);
+	}
+
+	public ConsultantException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public ConsultantException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/src/main/java/me/magnet/consultant/Service.java
+++ b/src/main/java/me/magnet/consultant/Service.java
@@ -1,0 +1,58 @@
+package me.magnet.consultant;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Service {
+
+	@JsonProperty("Node")
+	private String node;
+
+	@JsonProperty("Address")
+	private String address;
+
+	@JsonProperty("ServiceID")
+	private String serviceId;
+
+	@JsonProperty("ServiceName")
+	private String serviceName;
+
+	@JsonProperty("ServiceTags")
+	private String[] serviceTags;
+
+	@JsonProperty("ServiceAddress")
+	private String serviceAddress;
+
+	@JsonProperty("ServicePort")
+	private Integer servicePort;
+
+	public String getNode() {
+		return node;
+	}
+
+	public String getAddress() {
+		return address;
+	}
+
+	public String getServiceId() {
+		return serviceId;
+	}
+
+	public String getServiceName() {
+		return serviceName;
+	}
+
+	public String[] getServiceTags() {
+		return serviceTags;
+	}
+
+	public String getServiceAddress() {
+		return serviceAddress;
+	}
+
+	public Integer getServicePort() {
+		return servicePort;
+	}
+
+}

--- a/src/main/java/me/magnet/consultant/ServiceRegistration.java
+++ b/src/main/java/me/magnet/consultant/ServiceRegistration.java
@@ -1,0 +1,36 @@
+package me.magnet.consultant;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ServiceRegistration {
+
+	@JsonProperty("ID")
+	private final String id;
+
+	@JsonProperty("Name")
+	private final String name;
+
+	@JsonProperty("Tags")
+	private final String[] tags;
+
+	@JsonProperty("Address")
+	private final String address;
+
+	@JsonProperty("Port")
+	private final int port;
+
+	@JsonProperty("Check")
+	private final Check check;
+
+	ServiceRegistration(String id, String name, String address, int port, Check check, String... tags) {
+		this.id = id;
+		this.name = name;
+		this.address = address;
+		this.port = port;
+		this.tags = tags;
+		this.check = check;
+	}
+
+}


### PR DESCRIPTION
Allows us to register and deregister services to and from Consul.

Currently we do assign a random UUID to the `instance` variable in the `ServiceIdentifier` class, if no instance is specified through the environment variables. In that case a service (with a random UUID) is registered to Consul, and failing to deregister that service, will cause it to linger forever in Consul (until someone removes it with an API call).

To combat this, the `INSTANCE` variable should be defined explicitly in the environment variables.

Unfortunately also no tests, since this functionality is directly interacting with Consul and we typically mock these interactions to test higher-level behaviour.