### PR TITLE
Add builder methods for testing services relying on consultant.

### DIFF
--- a/src/main/java/me/magnet/consultant/Consultant.java
+++ b/src/main/java/me/magnet/consultant/Consultant.java
@@ -60,12 +60,16 @@ public class Consultant {
 		private ServiceIdentifier id;
 		private ConfigValidator validator;
 		private CloseableHttpClient http;
+		private Properties properties;
+		private boolean pullConfig;
 		private final SetMultimap<String, SettingListener> settingListeners;
 		private final Set<ConfigListener> configListeners;
 
 		private Builder() {
 			this.settingListeners = HashMultimap.create();
 			this.configListeners = Sets.newHashSet();
+			this.properties = new Properties();
+			this.pullConfig = true;
 		}
 
 		/**
@@ -210,6 +214,32 @@ public class Consultant {
 		}
 
 		/**
+		 * Specifies that Consultant should or should not fetch configuration from Consul. By default this is set to
+		 * true, but it can be useful to set this to false for testing.
+		 *
+		 * @param pullConfig True if configuration should be retrieved from Consul, or false if it should not.
+		 * @return The Builder instance.
+		 */
+		public Builder pullConfigFromConsul(boolean pullConfig) {
+			this.pullConfig = pullConfig;
+			return this;
+		}
+
+		/**
+		 * Ensures that Consultant starts out with a default Properties object. This object will be updated if
+		 * Consultant pulls configuration from Consul. By default Consultant will start out with an empty Properties
+		 * object.
+		 *
+		 * @param properties The Properties object to start Consultant with.
+		 * @return The Builder instance.
+		 */
+		public Builder startWith(Properties properties) {
+			checkArgument(properties != null, "You must specify a non-null Properties object!");
+			this.properties = properties;
+			return this;
+		}
+
+		/**
 		 * Builds a new instance of the Consultant class using the specified arguments.
 		 *
 		 * @return The constructed Consultant object.
@@ -249,7 +279,7 @@ public class Consultant {
 			}
 
 			Consultant consultant = new Consultant(executor, host, id, settingListeners, configListeners, validator,
-					http);
+					http, pullConfig, properties);
 
 			consultant.init();
 
@@ -290,13 +320,14 @@ public class Consultant {
 	private final ObjectMapper mapper;
 	private final ConfigValidator validator;
 	private final Properties validated;
+	private final boolean pullConfig;
 
 	private final Multimap<String, SettingListener> settingListeners;
 	private final Set<ConfigListener> configListeners;
 
 	private Consultant(ScheduledExecutorService executor, String host, ServiceIdentifier identifier,
 			SetMultimap<String, SettingListener> settingListeners, Set<ConfigListener> configListeners,
-			ConfigValidator validator, CloseableHttpClient http) {
+			ConfigValidator validator, CloseableHttpClient http, boolean pullConfig, Properties properties) {
 
 		this.registered = new AtomicBoolean();
 		this.settingListeners = Multimaps.synchronizedSetMultimap(settingListeners);
@@ -306,11 +337,16 @@ public class Consultant {
 		this.executor = executor;
 		this.host = host;
 		this.id = identifier;
-		this.validated = new Properties();
+		this.pullConfig = pullConfig;
+		this.validated = properties;
 		this.http = http;
 	}
 
 	private void init() {
+		if (!pullConfig) {
+			return;
+		}
+
 		log.info("Fetching initial configuration from Consul...");
 		ConfigUpdater poller = new ConfigUpdater(executor, http, host, null, id, mapper, null, (properties) -> {
 			if (validator == null) {
@@ -471,7 +507,10 @@ public class Consultant {
 	 * Tears any outstanding resources down.
 	 */
 	public void shutdown() {
-		executor.shutdownNow();
+		if (pullConfig) {
+			executor.shutdownNow();
+		}
+
 		try {
 			try {
 				deregisterService();


### PR DESCRIPTION
When using Consultant in tests, it's a good idea to mock interactions with Consul. This PR serves as a first step in doing so. In the Builder you'll now have access to two new methods `pullConfigFromConsul(boolean)` which allows you to prevent Consultant from pulling data from Consul, and `startWith(Properties)` which allows you to start with a specific set of settings.