### PR TITLE
Only return healthy services when locating or listing services.

### DIFF
--- a/src/main/java/me/magnet/consultant/Consultant.java
+++ b/src/main/java/me/magnet/consultant/Consultant.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Strings;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -436,8 +435,8 @@ public class Consultant {
 		}
 	}
 
-	public List<Service> list(String serviceName) {
-		String url = host + "/v1/catalog/service/" + serviceName;
+	public List<ServiceInstance> list(String serviceName) {
+		String url = host + "/v1/health/service/" + serviceName + "?passing&near=_agent";
 
 		HttpGet request = new HttpGet(url);
 		request.setHeader("User-Agent", "Consultant");
@@ -445,7 +444,7 @@ public class Consultant {
 			int statusCode = response.getStatusLine().getStatusCode();
 			if (statusCode >= 200 && statusCode < 300) {
 				InputStream content = response.getEntity().getContent();
-				return mapper.readValue(content, new TypeReference<List<Service>>() {});
+				return mapper.readValue(content, new TypeReference<List<ServiceInstance>>() {});
 			}
 			log.error("Could not locate service: " + serviceName + ", status: " + statusCode);
 			throw new ConsultantException("Could not locate service: " + serviceName + ". Consul returned: " + statusCode);
@@ -459,11 +458,13 @@ public class Consultant {
 	public Optional<InetSocketAddress> locate(String serviceName) {
 		return list(serviceName).stream()
 				.findFirst()
-				.map(service -> {
-					String address = Optional.ofNullable(Strings.emptyToNull(service.getServiceAddress()))
+				.map(instance -> {
+					Node node = instance.getNode();
+					Service service = instance.getService();
+					String address = Optional.ofNullable(node.getAddress())
 							.orElse(service.getAddress());
 
-					return new InetSocketAddress(address, service.getServicePort());
+					return new InetSocketAddress(address, service.getPort());
 				});
 	}
 

--- a/src/main/java/me/magnet/consultant/Node.java
+++ b/src/main/java/me/magnet/consultant/Node.java
@@ -1,0 +1,23 @@
+package me.magnet.consultant;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Node {
+
+	@JsonProperty("Node")
+	private String node;
+
+	@JsonProperty("Address")
+	private String address;
+
+	public String getNode() {
+		return node;
+	}
+
+	public String getAddress() {
+		return address;
+	}
+
+}

--- a/src/main/java/me/magnet/consultant/Service.java
+++ b/src/main/java/me/magnet/consultant/Service.java
@@ -6,53 +6,39 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Service {
 
-	@JsonProperty("Node")
-	private String node;
+	@JsonProperty("Id")
+	private String id;
+
+	@JsonProperty("Service")
+	private String service;
+
+	@JsonProperty("Tags")
+	private String[] tags;
 
 	@JsonProperty("Address")
 	private String address;
 
-	@JsonProperty("ServiceID")
-	private String serviceId;
+	@JsonProperty("Port")
+	private Integer port;
 
-	@JsonProperty("ServiceName")
-	private String serviceName;
+	public String getId() {
+		return id;
+	}
 
-	@JsonProperty("ServiceTags")
-	private String[] serviceTags;
+	public String getService() {
+		return service;
+	}
 
-	@JsonProperty("ServiceAddress")
-	private String serviceAddress;
-
-	@JsonProperty("ServicePort")
-	private Integer servicePort;
-
-	public String getNode() {
-		return node;
+	public String[] getTags() {
+		return tags;
 	}
 
 	public String getAddress() {
 		return address;
 	}
 
-	public String getServiceId() {
-		return serviceId;
-	}
-
-	public String getServiceName() {
-		return serviceName;
-	}
-
-	public String[] getServiceTags() {
-		return serviceTags;
-	}
-
-	public String getServiceAddress() {
-		return serviceAddress;
-	}
-
-	public Integer getServicePort() {
-		return servicePort;
+	public Integer getPort() {
+		return port;
 	}
 
 }

--- a/src/main/java/me/magnet/consultant/ServiceInstance.java
+++ b/src/main/java/me/magnet/consultant/ServiceInstance.java
@@ -1,0 +1,33 @@
+package me.magnet.consultant;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ServiceInstance {
+
+	@JsonProperty("Node")
+	private final Node node;
+
+	@JsonProperty("Service")
+	private final Service service;
+
+	private ServiceInstance() {
+		this.node = null;
+		this.service = null;
+	}
+
+	ServiceInstance(Node node, Service service) {
+		this.node = node;
+		this.service = service;
+	}
+
+	public Node getNode() {
+		return node;
+	}
+
+	public Service getService() {
+		return service;
+	}
+
+}


### PR DESCRIPTION
This PR fixes an issue where the services returned through the `locate` and `list` methods also contained unhealthy or offline services. This is fixed by calling a different Consul endpoint which allows us to filter service on their health state. 

As a small improvement we also supply the `?near=_agent` query parameter to tell Consul we'd like to have the resulting list of services ordered according to network/latency distance. So in theory, when using `locate` to communicate with another service, we should always be talking to the closest healthy instance of that service.