### PR TITLE
Allow Consultant to wait for task termination

### DIFF
--- a/src/test/java/me/magnet/consultant/ConsultantConfigurationProviderTest.java
+++ b/src/test/java/me/magnet/consultant/ConsultantConfigurationProviderTest.java
@@ -39,7 +39,7 @@ public class ConsultantConfigurationProviderTest {
 	}
 
 	@After
-	public void tearDown() {
+	public void tearDown() throws InterruptedException {
 		consultant.shutdown();
 	}
 

--- a/src/test/java/me/magnet/consultant/ConsultantTest.java
+++ b/src/test/java/me/magnet/consultant/ConsultantTest.java
@@ -38,7 +38,7 @@ public class ConsultantTest {
 	}
 
 	@After
-	public void tearDown() {
+	public void tearDown() throws InterruptedException {
 		if (consultant != null) {
 			consultant.shutdown();
 		}


### PR DESCRIPTION
When calling `shutdown()` before, there was no waiting for the termination of the tasks. Because of the `http.close()` right afterwards, it would mean that any task depending on that http client could very likely crash while trying to operate on it while it was in fact already closed.