### PR TITLE
Add tag support to consultant

### DIFF
--- a/src/main/java/me/magnet/consultant/Consultant.java
+++ b/src/main/java/me/magnet/consultant/Consultant.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.HttpEntity;
@@ -243,9 +244,9 @@ public class Consultant {
 		}
 
 		public Builder withTag(String tag) {
-			if ( tag != null) {
-				this.tags.add(tag);
-			}
+			Preconditions.checkArgument(!Strings.isNullOrEmpty(tag), "enter a non-empty tag name");
+
+			this.tags.add(tag);
 			return this;
 		}
 
@@ -375,7 +376,9 @@ public class Consultant {
 			instanceName = Optional.ofNullable(instanceName)
 					.orElse(Optional.ofNullable(fromEnvironment("SERVICE_INSTANCE"))
 							.orElse(UUID.randomUUID().toString()));
-			Arrays.stream(Strings.nullToEmpty(fromEnvironment("SERVICE_TAGS")).split(",")).forEach((tag) -> tags.add(tag));
+			Arrays.stream(Strings.nullToEmpty(fromEnvironment("SERVICE_TAGS")).split(","))
+					.filter((t) -> !Strings.isNullOrEmpty(t))
+					.forEach(tags::add);
 
 			if (mapper == null) {
 				mapper = new ObjectMapper();

--- a/src/main/java/me/magnet/consultant/ServiceIdentifier.java
+++ b/src/main/java/me/magnet/consultant/ServiceIdentifier.java
@@ -138,6 +138,7 @@ public class ServiceIdentifier {
 		getDatacenter().ifPresent(dc -> descriptors.add("dc=" + dc));
 		getHostName().ifPresent(host -> descriptors.add("host=" + host));
 		getInstance().ifPresent(instance -> descriptors.add("instance=" + instance));
+		getTags().stream().forEach((tag) -> descriptors.add("tag=" + tag));
 
 		StringBuilder builder = new StringBuilder(serviceName);
 		if (!descriptors.isEmpty()) {

--- a/src/main/java/me/magnet/consultant/ServiceIdentifier.java
+++ b/src/main/java/me/magnet/consultant/ServiceIdentifier.java
@@ -6,9 +6,11 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -18,17 +20,24 @@ public class ServiceIdentifier {
 	private final Optional<String> datacenter;
 	private final Optional<String> hostName;
 	private final Optional<String> instance;
+	private final Set<String> tags;
 
 	ServiceIdentifier(String serviceName, String datacenter, String hostName, String instance) {
+		this(serviceName, datacenter, hostName, instance, Sets.newHashSet());
+	}
+
+	ServiceIdentifier(String serviceName, String datacenter, String hostName, String instance, Set<String> tags) {
 		checkArgument(!isNullOrEmpty(serviceName), "You must specify a 'serviceName'!");
 		checkArgument(datacenter == null || !datacenter.isEmpty(), "You cannot specify 'datacenter' as empty String!");
 		checkArgument(hostName == null || !hostName.isEmpty(), "You cannot specify 'hostName' as empty String!");
 		checkArgument(instance == null || !instance.isEmpty(), "You cannot specify 'instance' as empty String!");
+		checkArgument(tags != null, "You cannot specify 'tags' as a null Set!");
 
 		this.datacenter = Optional.ofNullable(datacenter);
 		this.hostName = Optional.ofNullable(hostName);
 		this.serviceName = serviceName;
 		this.instance = Optional.ofNullable(instance);
+		this.tags = tags;
 	}
 
 	public String getServiceName() {
@@ -45,6 +54,10 @@ public class ServiceIdentifier {
 
 	public Optional<String> getInstance() {
 		return instance;
+	}
+
+	public Set<String> getTags() {
+		return tags;
 	}
 
 	public boolean appliesTo(ServiceIdentifier serviceIdentifier) {
@@ -102,6 +115,7 @@ public class ServiceIdentifier {
 					.append(datacenter, id.datacenter)
 					.append(hostName, id.hostName)
 					.append(instance, id.instance)
+					.append(tags, id.tags)
 					.isEquals();
 		}
 		return false;
@@ -114,6 +128,7 @@ public class ServiceIdentifier {
 				.append(datacenter)
 				.append(hostName)
 				.append(instance)
+				.append(tags)
 				.toHashCode();
 	}
 

--- a/src/main/java/me/magnet/consultant/ServiceIdentifier.java
+++ b/src/main/java/me/magnet/consultant/ServiceIdentifier.java
@@ -138,7 +138,7 @@ public class ServiceIdentifier {
 		getDatacenter().ifPresent(dc -> descriptors.add("dc=" + dc));
 		getHostName().ifPresent(host -> descriptors.add("host=" + host));
 		getInstance().ifPresent(instance -> descriptors.add("instance=" + instance));
-		getTags().stream().forEach((tag) -> descriptors.add("tag=" + tag));
+		descriptors.add("tags=[" + getTags().stream().collect(Collectors.joining(",")) + "]");
 
 		StringBuilder builder = new StringBuilder(serviceName);
 		if (!descriptors.isEmpty()) {

--- a/src/main/java/me/magnet/consultant/ServiceRegistration.java
+++ b/src/main/java/me/magnet/consultant/ServiceRegistration.java
@@ -1,5 +1,7 @@
 package me.magnet.consultant;
 
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -24,12 +26,12 @@ public class ServiceRegistration {
 	@JsonProperty("Check")
 	private final Check check;
 
-	ServiceRegistration(String id, String name, String address, int port, Check check, String... tags) {
+	ServiceRegistration(String id, String name, String address, int port, Check check, Set<String> tags) {
 		this.id = id;
 		this.name = name;
 		this.address = address;
 		this.port = port;
-		this.tags = tags;
+		this.tags = tags.toArray(new String[tags.size()]);
 		this.check = check;
 	}
 

--- a/src/test/java/me/magnet/consultant/ConsultantTest.java
+++ b/src/test/java/me/magnet/consultant/ConsultantTest.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.SettableFuture;
 import me.magnet.consultant.Consultant.Builder.Agent;
 import me.magnet.consultant.Consultant.Builder.Config;
@@ -26,6 +27,8 @@ import org.apache.http.message.BasicHeader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Set;
 
 public class ConsultantTest {
 
@@ -60,6 +63,7 @@ public class ConsultantTest {
 				.usingHttpClient(httpBuilder.create())
 				.withConsulHost("http://localhost")
 				.identifyAs("oauth", "eu-central", "web-1", "master")
+				.withTag("test")
 				.onValidConfig(future::set)
 				.build();
 
@@ -83,6 +87,7 @@ public class ConsultantTest {
 				.usingHttpClient(httpBuilder.create())
 				.withConsulHost("http://localhost")
 				.identifyAs("oauth", "eu-central", "web-1", "master")
+				.withTag("test")
 				.onValidConfig(future::set)
 				.validateConfigWith((config) -> {
 					throw new IllegalArgumentException("Config is invalid");
@@ -108,6 +113,7 @@ public class ConsultantTest {
 				.usingHttpClient(httpBuilder.create())
 				.withConsulHost("http://localhost")
 				.identifyAs("oauth", "eu-central", "web-1", "master")
+				.withTag("test")
 				.onValidConfig(future::set)
 				.build();
 
@@ -132,6 +138,7 @@ public class ConsultantTest {
 				.usingHttpClient(httpBuilder.create())
 				.withConsulHost("http://localhost")
 				.identifyAs("oauth", "eu-central", "web-1", "master")
+				.withTag("test")
 				.onSettingUpdate("some.key", (key, oldValue, newValue) -> {
 					future.set(Triple.of(key, oldValue, newValue));
 				})
@@ -165,6 +172,7 @@ public class ConsultantTest {
 				.usingHttpClient(httpBuilder.create())
 				.withConsulHost("http://localhost")
 				.identifyAs("oauth", "eu-central", "web-1", "master")
+				.withTag("test")
 				.onSettingUpdate("some.key", (key, oldValue, newValue) -> {
 					if (oldValue != null) {
 						future.set(Triple.of(key, oldValue, newValue));
@@ -251,12 +259,17 @@ public class ConsultantTest {
 		System.setProperty("SERVICE_DC", "eu-central");
 		System.setProperty("SERVICE_HOST", "web-1");
 		System.setProperty("SERVICE_INSTANCE", "master");
+		System.setProperty("SERVICE_TAGS", "gitsha,production");
 
 		consultant = Consultant.builder()
 				.usingHttpClient(httpBuilder.create())
 				.build();
 
-		ServiceIdentifier id = new ServiceIdentifier("oauth", "eu-central", "web-1", "master");
+		Set<String> tags = Sets.newHashSet();
+		tags.add("production");
+		tags.add("gitsha");
+
+		ServiceIdentifier id = new ServiceIdentifier("oauth", "eu-central", "web-1", "master", tags);
 		assertEquals(id, consultant.getServiceIdentifier());
 	}
 

--- a/src/test/java/me/magnet/consultant/ConsultantTest.java
+++ b/src/test/java/me/magnet/consultant/ConsultantTest.java
@@ -307,6 +307,23 @@ public class ConsultantTest {
 	}
 
 	@Test
+	public void verifyEmptyTagsDoNotFail() throws Exception {
+		System.setProperty("CONSUL_HOST", "http://localhost");
+		System.setProperty("SERVICE_NAME", "oauth");
+		System.setProperty("SERVICE_DC", "eu-central");
+		System.setProperty("SERVICE_HOST", "web-1");
+		System.setProperty("SERVICE_INSTANCE", "master");
+		System.setProperty("SERVICE_TAGS", "");
+
+		consultant = Consultant.builder()
+				.usingHttpClient(httpBuilder.create())
+				.build();
+
+		ServiceIdentifier id = new ServiceIdentifier("oauth", "eu-central", "web-1", "master");
+		assertEquals(id, consultant.getServiceIdentifier());
+	}
+
+	@Test
 	public void verifyConfigListenerCanBeRemoved() throws Exception {
 		ConfigListener listener = System.out::println;
 		consultant = Consultant.builder()

--- a/src/test/java/me/magnet/consultant/ServiceIdentifierTest.java
+++ b/src/test/java/me/magnet/consultant/ServiceIdentifierTest.java
@@ -3,6 +3,9 @@ package me.magnet.consultant;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Set;
+
+import com.google.common.collect.Sets;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
@@ -136,6 +139,28 @@ public class ServiceIdentifierTest {
 
 		assertFalse(id2.appliesTo(id1));
 		assertFalse(id1.appliesTo(id2));
+	}
+
+	@Test public void verifyEmptyTagSet() {
+		ServiceIdentifier id = new ServiceIdentifier("oauth", null, null, null);
+		ServiceIdentifier id2 = new ServiceIdentifier("oauth", null, null, null, Sets.newHashSet());
+
+		assertTrue(id.getTags() != null);
+		assertTrue(id2.getTags() != null);
+		assertTrue(id.getTags().size() == 0);
+		assertTrue(id2.getTags().size() == 0);
+	}
+
+	@Test public void verifyNonEmptyTagSet() {
+		Set<String> tags = Sets.newHashSet();
+		tags.add("oauth");
+		tags.add("production-traffic");
+		ServiceIdentifier id = new ServiceIdentifier("oauth", null, null, null, tags);
+
+		assertTrue(id.getTags() != null);
+		assertTrue(id.getTags().size() == 2);
+		assertTrue(id.getTags().contains("oauth"));
+		assertTrue(id.getTags().contains("production-traffic"));
 	}
 
 	@Test


### PR DESCRIPTION
Supersedes #11 

The goal of adding tags to Consultant is the way we can tag instances. Examples are the built time, the git sha, or whether this instance is allowed to receive production traffic. Other infrastructure services down the road can inspect and use these tags to determine where to send traffic.

@Magnetme/monolith ready for review!