### PR TITLE
Round robin requests instead of sorting by nearness

### DIFF
--- a/src/main/java/me/magnet/consultant/Consultant.java
+++ b/src/main/java/me/magnet/consultant/Consultant.java
@@ -9,6 +9,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -559,7 +560,7 @@ public class Consultant {
 	}
 
 	public List<ServiceInstance> list(String serviceName) {
-		String url = consulUri + "/v1/health/service/" + serviceName + "?passing&near=_agent";
+		String url = consulUri + "/v1/health/service/" + serviceName + "?passing";
 
 		HttpGet request = new HttpGet(url);
 		request.setHeader("User-Agent", "Consultant");
@@ -567,7 +568,11 @@ public class Consultant {
 			int statusCode = response.getStatusLine().getStatusCode();
 			if (statusCode >= 200 && statusCode < 400) {
 				InputStream content = response.getEntity().getContent();
-				return mapper.readValue(content, new TypeReference<List<ServiceInstance>>() {});
+				List<ServiceInstance> instanceLocations =
+						mapper.readValue(content, new TypeReference<List<ServiceInstance>>() {
+						});
+				Collections.shuffle(instanceLocations);
+				return instanceLocations;
 			}
 			log.error("Could not locate service: " + serviceName + ", status: " + statusCode);
 			throw new ConsultantException("Could not locate service: " + serviceName + ". Consul returned: " + statusCode);


### PR DESCRIPTION
The current implementation will always pick the closest service in terms of nearness, based on pings. However due to network layout, some servers are slightly further away and will therefore never receive any requests, until a server is overloaded in such a way its ping times will increase. From that moment on, another server will be bombared until that either the first one restores or the second one also collapses (whichever comes first).

Since the internal ping times are very low anyway, the difference is only around 0.1ms. The total request time is therefore governated by the response time of the called server. This fix implements round robin load balancing, which is fine for internal requests where the response time of the server is significantly larger than the ping time.

@Magnetme/monolith ready for review

_Long part here_:

Keeping request as locally as possible can be very useful in order to prevent lots of datatraffic data centre wide. However for the amount of traffic we are currently dealing with this can be considered to be overkill. In case this becomes an issue, we should define nearness as a function of distance (can be based on ping) and server loads as well. Probably we might need to complicate stuff a bit more: Imagine a service which calls some broker, one instance is very local and the other one isnt. In this case the local broker is picked. However, in case this broker interacts with other services which are all closes to the remote broker, the latter option might be preferable since it will reduce the total response time.