### PR TITLE
Do not log as error when the service consultant is bound to is shutting down

### DIFF
--- a/src/main/java/me/magnet/consultant/ConfigUpdater.java
+++ b/src/main/java/me/magnet/consultant/ConfigUpdater.java
@@ -43,6 +43,7 @@ class ConfigUpdater implements Runnable {
 	}
 
 	private static final Logger log = LoggerFactory.getLogger(ConfigUpdater.class);
+	private static final String shutdownMessage = "Connection pool shut down";
 
 	private static final String PREFIX = "config";
 
@@ -108,7 +109,12 @@ class ConfigUpdater implements Runnable {
 			}
 		}
 		catch (IOException | RuntimeException e) {
-			log.error("Error occurred while retrieving/publishing new config from Consul: " + e.getMessage(), e);
+			if (e instanceof IllegalStateException && e.getMessage().equals(shutdownMessage)) {
+				log.info("The service is being shutdown, could not get a new configuration");
+			}
+			else{
+				log.error("Error occurred while retrieving/publishing new config from Consul: " + e.getMessage(), e);
+			}
 		}
 		finally {
 			ConfigUpdater task = new ConfigUpdater(executor, httpClient, consulURI, consulIndex, identifier,


### PR DESCRIPTION
This is throwing quite some (useless) errors, so we simply check the message
to determine when this is the case.

If this is happening, dont log it as an error (since its not an error)

@Magnetme/developers ready for review!