### PR TITLE
Fix shutdown procedure

### DIFF
--- a/src/main/java/me/magnet/consultant/Consultant.java
+++ b/src/main/java/me/magnet/consultant/Consultant.java
@@ -666,11 +666,13 @@ public class Consultant {
 	 * @throws InterruptedException If it got interrupted while waiting for any open tasks
 	 */
 	public void shutdown() throws InterruptedException {
-		try {
-			deregisterService();
-		}
-		catch (ConsultantException e) {
-			log.error("Error occurred while deregistering", e);
+		if (registered.get()) {
+			try {
+				deregisterService();
+			}
+			catch (ConsultantException e) {
+				log.error("Error occurred while deregistering", e);
+			}
 		}
 
 		if (pullConfig && !executor.isShutdown()) {

--- a/src/main/java/me/magnet/consultant/Consultant.java
+++ b/src/main/java/me/magnet/consultant/Consultant.java
@@ -676,7 +676,11 @@ public class Consultant {
 		}
 
 		if (pullConfig && !executor.isShutdown()) {
-			MoreExecutors.shutdownAndAwaitTermination(executor, TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+			boolean shutDownTasks =
+					MoreExecutors.shutdownAndAwaitTermination(executor, TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+			if (!shutDownTasks) {
+				log.warn("Could not shut down all executor tasks!");
+			}
 		}
 
 		try {


### PR DESCRIPTION
This PR fixes several minor issues with Consultant's shutdown procedure:
- Instead of shutting down the http client first, which often leads to IllegalStateExceptions because the http connection pool was shut down while ConfigUpdater was retrieving its config, shut down the executor first, and only then the http client.
- Switch to the MoreExecutors shutdown procedure for the executor service, as it means not relying on a custom shutdown procedure.
- Don't log the failed deregister in the shutdown as a warning if the service has already been deregistered, as it's a valid use case.

@Magnetme/monolith RFR!