### PR TITLE
Feature/allow custom kv prefix

### DIFF
--- a/src/main/java/me/magnet/consultant/ConfigUpdater.java
+++ b/src/main/java/me/magnet/consultant/ConfigUpdater.java
@@ -138,7 +138,7 @@ class ConfigUpdater implements Runnable {
 		Map<String, Setting> newConfig = Maps.newHashMap();
 
 		for (KeyValueEntry entry : entries) {
-			Path path = PathParser.parse(PREFIX, entry.getKey());
+			Path path = PathParser.parse(kvPrefix, entry.getKey());
 			if (path == null || path.getKey() == null) {
 				continue;
 			}

--- a/src/main/java/me/magnet/consultant/ConfigUpdater.java
+++ b/src/main/java/me/magnet/consultant/ConfigUpdater.java
@@ -15,6 +15,7 @@ import java.net.URI;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -53,12 +54,13 @@ class ConfigUpdater implements Runnable {
 	private final ObjectMapper objectMapper;
 	private final Properties config;
 	private final ConfigListener listener;
+	private final String kvPrefix;
 
 	private String consulIndex;
 
 	ConfigUpdater(ScheduledExecutorService executor, CloseableHttpClient httpClient, URI consulURI,
 			String consulIndex, ServiceIdentifier identifier, ObjectMapper objectMapper,
-			Properties config, ConfigListener listener) {
+			Properties config, ConfigListener listener, String kvPrefix) {
 
 		this.httpClient = httpClient;
 		this.consulIndex = consulIndex;
@@ -67,14 +69,15 @@ class ConfigUpdater implements Runnable {
 		this.consulURI = consulURI;
 		this.identifier = identifier;
 		this.listener = listener;
-		this.config = config != null ? config : new Properties();
+		this.config = Optional.ofNullable(config).orElse(new Properties());
+		this.kvPrefix = Optional.ofNullable(kvPrefix).orElse(PREFIX);
 	}
 
 	@Override
 	public void run() {
 		long timeout = 500;
 		try {
-			String url = consulURI + "/v1/kv/" + PREFIX + "/" + identifier.getServiceName() + "/?recurse=true";
+			String url = consulURI + "/v1/kv/" + kvPrefix + "/" + identifier.getServiceName() + "/?recurse=true";
 			if (consulIndex != null) {
 				url += "&index=" + consulIndex;
 			}
@@ -112,7 +115,7 @@ class ConfigUpdater implements Runnable {
 		}
 		finally {
 			ConfigUpdater task = new ConfigUpdater(executor, httpClient, consulURI, consulIndex, identifier,
-					objectMapper, config, listener);
+					objectMapper, config, listener, kvPrefix);
 
 			executor.schedule(task, timeout, TimeUnit.MILLISECONDS);
 		}

--- a/src/test/java/me/magnet/consultant/ConfigUpdaterTest.java
+++ b/src/test/java/me/magnet/consultant/ConfigUpdaterTest.java
@@ -57,7 +57,7 @@ public class ConfigUpdaterTest {
 		CloseableHttpResponse response = mock(CloseableHttpResponse.class);
 		when(response.getFirstHeader(eq("X-Consul-Index"))).thenReturn(new BasicHeader("X-Consul-Index", "1000"));
 		when(response.getStatusLine()).thenReturn(createStatus(200, "OK"));
-		when(response.getEntity()).thenReturn(toJson(ImmutableMap.of("config/oauth/some.key", "some-value")));
+		when(response.getEntity()).thenReturn(toJson(ImmutableMap.of("some-prefix/oauth/some.key", "some-value")));
 
 		when(http.execute(any())).thenReturn(response);
 
@@ -74,12 +74,12 @@ public class ConfigUpdaterTest {
 		CloseableHttpResponse response1 = mock(CloseableHttpResponse.class);
 		when(response1.getFirstHeader(eq("X-Consul-Index"))).thenReturn(new BasicHeader("X-Consul-Index", "1000"));
 		when(response1.getStatusLine()).thenReturn(createStatus(200, "OK"));
-		when(response1.getEntity()).thenReturn(toJson(ImmutableMap.of("config/oauth/some.key", "some-value")));
+		when(response1.getEntity()).thenReturn(toJson(ImmutableMap.of("some-prefix/oauth/some.key", "some-value")));
 
 		CloseableHttpResponse response2 = mock(CloseableHttpResponse.class);
 		when(response2.getFirstHeader(eq("X-Consul-Index"))).thenReturn(new BasicHeader("X-Consul-Index", "1001"));
 		when(response2.getStatusLine()).thenReturn(createStatus(200, "OK"));
-		when(response2.getEntity()).thenReturn(toJson(ImmutableMap.of("config/oauth/some.key", "some-other-value")));
+		when(response2.getEntity()).thenReturn(toJson(ImmutableMap.of("some-prefix/oauth/some.key", "some-other-value")));
 
 		when(http.execute(any())).thenReturn(response1, response2);
 
@@ -101,8 +101,8 @@ public class ConfigUpdaterTest {
 		CloseableHttpResponse response = mock(CloseableHttpResponse.class);
 		when(response.getFirstHeader(eq("X-Consul-Index"))).thenReturn(new BasicHeader("X-Consul-Index", "1000"));
 		when(response.getStatusLine()).thenReturn(createStatus(200, "OK"));
-		when(response.getEntity()).thenReturn(toJson(ImmutableMap.of("config/oauth/", "some-value",
-				"config/oauth/some.key", "some-value")));
+		when(response.getEntity()).thenReturn(toJson(ImmutableMap.of("some-prefix/oauth/", "some-value",
+				"some-prefix/oauth/some.key", "some-value")));
 
 		when(http.execute(any())).thenReturn(response);
 
@@ -119,7 +119,7 @@ public class ConfigUpdaterTest {
 		CloseableHttpResponse response1 = mock(CloseableHttpResponse.class);
 		when(response1.getFirstHeader(eq("X-Consul-Index"))).thenReturn(new BasicHeader("X-Consul-Index", "1000"));
 		when(response1.getStatusLine()).thenReturn(createStatus(200, "OK"));
-		when(response1.getEntity()).thenReturn(toJson(ImmutableMap.of("config/oauth/some.key", "some-value")));
+		when(response1.getEntity()).thenReturn(toJson(ImmutableMap.of("some-prefix/oauth/some.key", "some-value")));
 
 		when(http.execute(any())).thenReturn(response1);
 

--- a/src/test/java/me/magnet/consultant/ConfigUpdaterTest.java
+++ b/src/test/java/me/magnet/consultant/ConfigUpdaterTest.java
@@ -62,7 +62,7 @@ public class ConfigUpdaterTest {
 		when(http.execute(any())).thenReturn(response);
 
 		SettableFuture<Properties> future = SettableFuture.create();
-		ConfigUpdater updater = new ConfigUpdater(executor, http, null, null, id, objectMapper, null, future::set);
+		ConfigUpdater updater = new ConfigUpdater(executor, http, null, null, id, objectMapper, null, future::set, "some-prefix");
 		updater.run();
 
 		Properties properties = future.get();
@@ -89,7 +89,7 @@ public class ConfigUpdaterTest {
 		ConfigUpdater updater = new ConfigUpdater(executor, http, null, null, id, objectMapper, null, (config) -> {
 			latch.countDown();
 			properties.set(config);
-		});
+		}, "some-prefix");
 		updater.run();
 
 		latch.await();
@@ -107,7 +107,7 @@ public class ConfigUpdaterTest {
 		when(http.execute(any())).thenReturn(response);
 
 		SettableFuture<Properties> future = SettableFuture.create();
-		ConfigUpdater updater = new ConfigUpdater(executor, http, null, null, id, objectMapper, null, future::set);
+		ConfigUpdater updater = new ConfigUpdater(executor, http, null, null, id, objectMapper, null, future::set, "some-prefix");
 		updater.run();
 
 		Properties properties = future.get();
@@ -125,7 +125,7 @@ public class ConfigUpdaterTest {
 
 		SettableFuture<Properties> future = SettableFuture.create();
 		id = new ServiceIdentifier("database", null, null, null);
-		ConfigUpdater updater = new ConfigUpdater(executor, http, null, null, id, objectMapper, null, future::set);
+		ConfigUpdater updater = new ConfigUpdater(executor, http, null, null, id, objectMapper, null, future::set, "some-prefix");
 		updater.run();
 
 		future.get(2000, TimeUnit.MILLISECONDS);
@@ -143,7 +143,7 @@ public class ConfigUpdaterTest {
 
 		SettableFuture<Properties> future = SettableFuture.create();
 		id = new ServiceIdentifier("oauth", null, null, null);
-		ConfigUpdater updater = new ConfigUpdater(executor, http, null, null, id, objectMapper, null, future::set);
+		ConfigUpdater updater = new ConfigUpdater(executor, http, null, null, id, objectMapper, null, future::set, "some-prefix");
 		updater.run();
 
 		Thread.sleep(5100);
@@ -160,7 +160,7 @@ public class ConfigUpdaterTest {
 		when(http.execute(any())).thenReturn(response1);
 		ScheduledExecutorService executorSpy = spy(executor);
 
-		ConfigUpdater updater = new ConfigUpdater(executor, http, null, null, id, objectMapper, null, null);
+		ConfigUpdater updater = new ConfigUpdater(executor, http, null, null, id, objectMapper, null, null, null);
 		updater.run();
 
 		Thread.sleep(1100);


### PR DESCRIPTION
We have an infrastructure whereby each environment is keyed by the environment name, followed by the service etc. thus, we need to change the `config` prefix for key/value.