### PR TITLE
Ensure the consultant client fires request to the Consul API using the appropriate HTTP verb

### DIFF
--- a/src/main/java/me/magnet/consultant/Consultant.java
+++ b/src/main/java/me/magnet/consultant/Consultant.java
@@ -34,7 +34,6 @@ import com.google.common.collect.Sets;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.StringEntity;
@@ -561,7 +560,7 @@ public class Consultant {
 		String url = consulUri + "/v1/agent/service/deregister/" + serviceId;
 		log.info("Deregistering service from Consul: {}", id);
 
-		HttpDelete request = new HttpDelete(url);
+		HttpPut request = new HttpPut(url);
 		request.setHeader("User-Agent", "Consultant");
 		try (CloseableHttpResponse response = http.execute(request)) {
 			int statusCode = response.getStatusLine().getStatusCode();


### PR DESCRIPTION
[Deregisters now use a PUT instead of a GET](https://www.consul.io/api/agent/service.html#deregister-service)

Not sure why its not a really restful API by using a DELETE, but let's just conform!

I'll update the version in a seperate PR 