### PR TITLE
Fix deserialization of Service objects in newer Consul versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.4.3</version>
+			<version>2.9.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/src/main/java/me/magnet/consultant/Service.java
+++ b/src/main/java/me/magnet/consultant/Service.java
@@ -1,12 +1,13 @@
 package me.magnet.consultant;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Service {
 
-	@JsonProperty("Id")
+	@JsonAlias({"ID", "Id"})
 	private String id;
 
 	@JsonProperty("Service")


### PR DESCRIPTION
Looks like the Consul version we're currently using (0.9.3) changed the json property from "Id" to "ID" for service objects in their API. This PR fixes that by adding "ID" as an alias for the "Id" key.