### PR TITLE
Specific key listener

### DIFF
--- a/src/main/java/me/magnet/consultant/Consultant.java
+++ b/src/main/java/me/magnet/consultant/Consultant.java
@@ -175,17 +175,17 @@ public class Consultant {
 			return this;
 		}
 
-        /**
-         * Allows the caller to specify the prefix when looking up the key value properties. This will default to
-         * {@code config} if not specified.
-         *
-         * @param kvPrefix the path prefix to be used when looking-up the properties.
-         * @return The Builder instance.
-         */
+		/**
+		 * Allows the caller to specify the prefix when looking up the key value properties. This will default to
+		 * {@code config} if not specified.
+		 *
+		 * @param kvPrefix the path prefix to be used when looking-up the properties.
+		 * @return The Builder instance.
+		 */
 		public Builder withKvPrefix(String kvPrefix) {
-            this.kvPrefix = kvPrefix;
-            return this;
-        }
+			this.kvPrefix = kvPrefix;
+			return this;
+		}
 
 		/**
 		 * States the identify of this application. This is used to figure out what configuration settings apply
@@ -208,7 +208,7 @@ public class Consultant {
 		 * value will default to the corresponding value of the Consul agent.
 		 *
 		 * @param serviceName The name of this service.
-		 * @param datacenter The name of the datacenter where this service is running in.
+		 * @param datacenter  The name of the datacenter where this service is running in.
 		 * @return The Builder instance.
 		 */
 		public Builder identifyAs(String serviceName, String datacenter) {
@@ -223,8 +223,8 @@ public class Consultant {
 		 * either, these values will default to the corresponding values of the Consul agent.
 		 *
 		 * @param serviceName The name of this service.
-		 * @param datacenter The name of the datacenter where this service is running in.
-		 * @param hostname The name of the host where this service is running on.
+		 * @param datacenter  The name of the datacenter where this service is running in.
+		 * @param hostname    The name of the host where this service is running on.
 		 * @return The Builder instance.
 		 */
 		public Builder identifyAs(String serviceName, String datacenter, String hostname) {
@@ -239,9 +239,9 @@ public class Consultant {
 		 * defined using environment variables either, these values will default to the corresponding values of
 		 * the Consul agent.
 		 *
-		 * @param serviceName The name of this service.
-		 * @param datacenter The name of the datacenter where this service is running in.
-		 * @param hostname The name of the host where this service is running on.
+		 * @param serviceName  The name of this service.
+		 * @param datacenter   The name of the datacenter where this service is running in.
+		 * @param hostname     The name of the host where this service is running on.
 		 * @param instanceName The name/role of this service instance.
 		 * @return The Builder instance.
 		 */
@@ -347,7 +347,7 @@ public class Consultant {
 		 * they've deregistered.
 		 *
 		 * @param duration The duration of time to cache locate call results for.
-		 * @param unit The unit of the specified duration.
+		 * @param unit     The unit of the specified duration.
 		 * @return The Builder instance.
 		 */
 		public Builder whenLocatingServicesCacheResultsFor(long duration, TimeUnit unit) {
@@ -435,7 +435,7 @@ public class Consultant {
 
 			ServiceIdentifier id = new ServiceIdentifier(serviceName, datacenter, hostname, instanceName);
 			Consultant consultant = new Consultant(executor, mapper, consulURI, id, settingListeners, configListeners,
-                    validator, http, pullConfig, healthEndpoint, kvPrefix, whenLocatingServicesCacheResultsFor);
+					validator, http, pullConfig, healthEndpoint, kvPrefix, whenLocatingServicesCacheResultsFor);
 
 			consultant.init(properties);
 			return consultant;
@@ -500,7 +500,7 @@ public class Consultant {
 		this.validated = new Properties();
 		this.healthEndpoint = healthEndpoint;
 		this.http = http;
-        this.kvPrefix = kvPrefix;
+		this.kvPrefix = kvPrefix;
 	}
 
 	private void init(Properties initProperties) {
@@ -550,7 +550,8 @@ public class Consultant {
 			String serviceName = id.getServiceName();
 			String serviceHost = id.getHostName().get();
 			Check check = new Check("http://" + serviceHost + ":" + port + healthEndpoint, HEALTH_CHECK_INTERVAL);
-			ServiceRegistration registration = new ServiceRegistration(serviceId, serviceName, serviceHost, port, check);
+			ServiceRegistration registration =
+					new ServiceRegistration(serviceId, serviceName, serviceHost, port, check);
 			String serialized = mapper.writeValueAsString(registration);
 
 			HttpPut request = new HttpPut(url);

--- a/src/main/java/me/magnet/consultant/Consultant.java
+++ b/src/main/java/me/magnet/consultant/Consultant.java
@@ -624,7 +624,6 @@ public class Consultant {
 	 * the "Randomized Weighted Distance" RoutingStrategy.
 	 *
 	 * @param serviceName The name of the service to locate instances of.
-	 *
 	 * @return The constructed ServiceLocator.
 	 */
 	public ServiceLocator locateAll(String serviceName) {
@@ -636,7 +635,6 @@ public class Consultant {
 	 *
 	 * @param serviceName     The name of the service to locate instances of.
 	 * @param routingStrategy The RoutingStrategy to use to locate instances.
-	 *
 	 * @return The constructed ServiceLocator.
 	 */
 	public ServiceLocator locateAll(String serviceName, RoutingStrategy routingStrategy) {
@@ -647,7 +645,6 @@ public class Consultant {
 	 * Returns the closest service instance's InetSocketAddress.
 	 *
 	 * @param serviceName The name of the service to locate.
-	 *
 	 * @return An Optional containing the closest service instance's InetSocketAddress, or an empty Optional otherwise.
 	 */
 	@Deprecated
@@ -708,6 +705,7 @@ public class Consultant {
 
 	/**
 	 * Tears any outstanding resources down.
+	 *
 	 * @throws InterruptedException If it got interrupted while waiting for any open tasks
 	 */
 	public void shutdown() throws InterruptedException {

--- a/src/main/java/me/magnet/consultant/Consultant.java
+++ b/src/main/java/me/magnet/consultant/Consultant.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -696,7 +697,10 @@ public class Consultant {
 
 			for (SettingListener listener : listeners) {
 				Pair<String, String> change = entry.getValue();
-				listener.onSettingUpdate(key, change.getLeft(), change.getRight());
+				if (!Objects.equals(change.getLeft(), change.getRight())) {
+					// Only fire this for keys which have actually been changed
+					listener.onSettingUpdate(key, change.getLeft(), change.getRight());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This prevents a listener from firing if another key has been changed. As some listeners might perform tasks which can be reset upon changed (such as creating a new ThreadPool when the number of threads changes) we do not want to do this when the old value and the new value are equal to each other.

Flyby: some minor autoformatting