### PR TITLE
Log warning when all known instances have at least one failing health check

### DIFF
--- a/src/main/java/me/magnet/consultant/CheckStatus.java
+++ b/src/main/java/me/magnet/consultant/CheckStatus.java
@@ -1,0 +1,42 @@
+package me.magnet.consultant;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CheckStatus {
+
+	@JsonProperty("Name")
+	private final String name;
+
+	@JsonProperty("Output")
+	private final String output;
+
+	@JsonProperty("Status")
+	private final String status;
+
+	CheckStatus() {
+		this.name = null;
+		this.output = null;
+		this.status = null;
+	}
+
+	CheckStatus(String name, String output, String status) {
+		this.name = name;
+		this.output = output;
+		this.status = status;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getOutput() {
+		return output;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+}

--- a/src/main/java/me/magnet/consultant/ServiceInstance.java
+++ b/src/main/java/me/magnet/consultant/ServiceInstance.java
@@ -1,7 +1,10 @@
 package me.magnet.consultant;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ServiceInstance {
@@ -12,14 +15,19 @@ public class ServiceInstance {
 	@JsonProperty("Service")
 	private final Service service;
 
+	@JsonProperty("Checks")
+	private final List<CheckStatus> checks;
+
 	private ServiceInstance() {
 		this.node = null;
 		this.service = null;
+		this.checks = null;
 	}
 
-	ServiceInstance(Node node, Service service) {
+	ServiceInstance(Node node, Service service, List<CheckStatus> checks) {
 		this.node = node;
 		this.service = service;
+		this.checks = checks;
 	}
 
 	public Node getNode() {
@@ -28,6 +36,10 @@ public class ServiceInstance {
 
 	public Service getService() {
 		return service;
+	}
+
+	public List<CheckStatus> getChecks() {
+		return ImmutableList.copyOf(checks);
 	}
 
 	@Override

--- a/src/test/java/me/magnet/consultant/RoutingStrategyTest.java
+++ b/src/test/java/me/magnet/consultant/RoutingStrategyTest.java
@@ -49,18 +49,21 @@ public abstract class RoutingStrategyTest {
 		Service service2 = createService(SERVICE_2);
 		Service service3 = createService(SERVICE_3);
 
-		this.dc1node1service1 = new ServiceInstance(dc1node1, service1);
-		this.dc1node2service1 = new ServiceInstance(dc1node2, service1);
-		this.dc1node3service1 = new ServiceInstance(dc1node3, service1);
-		this.dc2node1service1 = new ServiceInstance(dc2node1, service1);
+		CheckStatus passing = new CheckStatus("Serf test", "All is OK", "passing");
+		List<CheckStatus> checks = Lists.newArrayList(passing);
 
-		this.dc1node1service2 = new ServiceInstance(dc1node1, service2);
-		this.dc1node2service2 = new ServiceInstance(dc1node2, service2);
-		this.dc1node3service2 = new ServiceInstance(dc1node3, service2);
+		this.dc1node1service1 = new ServiceInstance(dc1node1, service1, checks);
+		this.dc1node2service1 = new ServiceInstance(dc1node2, service1, checks);
+		this.dc1node3service1 = new ServiceInstance(dc1node3, service1, checks);
+		this.dc2node1service1 = new ServiceInstance(dc2node1, service1, checks);
 
-		this.dc1node1service3 = new ServiceInstance(dc1node1, service3);
-		this.dc1node2service3 = new ServiceInstance(dc1node2, service3);
-		this.dc1node3service3 = new ServiceInstance(dc1node3, service3);
+		this.dc1node1service2 = new ServiceInstance(dc1node1, service2, checks);
+		this.dc1node2service2 = new ServiceInstance(dc1node2, service2, checks);
+		this.dc1node3service2 = new ServiceInstance(dc1node3, service2, checks);
+
+		this.dc1node1service3 = new ServiceInstance(dc1node1, service3, checks);
+		this.dc1node2service3 = new ServiceInstance(dc1node2, service3, checks);
+		this.dc1node3service3 = new ServiceInstance(dc1node3, service3, checks);
 
 		this.serviceInstanceBackend = mock(ServiceInstanceBackend.class);
 		when(serviceInstanceBackend.listInstances(anyString())).thenAnswer(invocation -> {


### PR DESCRIPTION
There's a recurring event where we seemingly cannot locate any instances for a given service where all checks are passing. This effectively returns an empty list of instances for the specified service. 

I'm relatively sure that these instances don't all magically decide to fail at least one of their health checks all at the same time, so it might be a networking issue or some internal process in Consul causing this. In order to debug this further (and make it apparent to the dev/ops person that this is happening), we should log such events when locating services.